### PR TITLE
[server] 모든 부서 공지사항 api 최적화

### DIFF
--- a/server/src/notice/notice.resolver.ts
+++ b/server/src/notice/notice.resolver.ts
@@ -33,19 +33,11 @@ export class NoticeResolver {
 
   @Query(() => [[NoticeType]])
   async getNoticesForEveryDepartments(@Args('count') limit: number) {
-    const departments = await this.departmentService.getAllDepartment();
-    const notices: Notice[][] = [];
-    for (const { id } of departments) {
-      const [
-        notice,
-      ] = await this.noticeService.getPaginatedNoticeByDepartmentId(
-        id,
-        limit,
-        0,
-      );
-      notices.push(notice);
-    }
-    return Promise.all(notices);
+    const notices = await this.noticeService.getNoticesForEveryDepartments(
+      limit,
+    );
+    console.log(notices);
+    return notices;
   }
 
   @Query(() => NoticeResponse)

--- a/server/src/notice/notice.resolver.ts
+++ b/server/src/notice/notice.resolver.ts
@@ -31,13 +31,9 @@ export class NoticeResolver {
     return await this.noticeService.getNotice(id);
   }
 
-  @Query(() => [[NoticeType]])
+  @Query(() => [NoticeType])
   async getNoticesForEveryDepartments(@Args('count') limit: number) {
-    const notices = await this.noticeService.getNoticesForEveryDepartments(
-      limit,
-    );
-    console.log(notices);
-    return notices;
+    return await this.noticeService.getNoticesForEveryDepartments(limit);
   }
 
   @Query(() => NoticeResponse)

--- a/server/src/notice/notice.service.ts
+++ b/server/src/notice/notice.service.ts
@@ -41,18 +41,22 @@ export class NoticeService {
     }
   }
 
-  async getNoticesForEveryDepartments(limit: number) {
-    const notices = await this.noticeRepository.query(`
-    SELECT (n).*
-    FROM (
-      SELECT
-        ROW_NUMBER() OVER (PARTITION BY "department" ORDER BY "n"."createdDatetime" DESC) AS r, n
-      FROM
-        notice n
-    ) x
-    WHERE x.r <= ${limit};
-    `);
-    return notices;
+  async getNoticesForEveryDepartments(limit: number): Promise<Notice[]> {
+    try {
+      const notices = await this.noticeRepository.query(`
+      SELECT (n).*
+      FROM (
+        SELECT
+          ROW_NUMBER() OVER (PARTITION BY "department" ORDER BY "n"."createdDatetime" DESC) AS r, n
+        FROM
+          notice n
+      ) x
+      WHERE x.r <= ${limit};
+      `);
+      return notices;
+    } catch (error) {
+      this.logger.error('get notices for every departments', error.stack);
+    }
   }
 
   async getPaginatedNoticeByDepartmentId(

--- a/server/src/notice/notice.service.ts
+++ b/server/src/notice/notice.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { createQueryBuilder, getRepository, Repository } from 'typeorm';
 import { CreateNoticeInput } from './notice.input';
 import { Notice } from './notice.entity';
 import { v4 as uuid } from 'uuid';
+import { Department } from '../department/department.entity';
 
 export const NOTICE_PAGINATED_BUNDLE_SIZE = 20;
 
@@ -39,6 +40,17 @@ export class NoticeService {
     } catch (error) {
       this.logger.error('get paginated all notice error', error.stack);
     }
+  }
+
+  async getNoticesForEveryDepartments(limit: number) {
+    const notices = await this.noticeRepository
+      .createQueryBuilder('notice')
+      .groupBy('notice.id')
+      .addGroupBy('notice.department')
+      .limit(limit)
+      .orderBy('notice.createdDatetime')
+      .getMany();
+    return notices;
   }
 
   async getPaginatedNoticeByDepartmentId(

--- a/server/src/schema.gql
+++ b/server/src/schema.gql
@@ -179,7 +179,7 @@ type Query {
     last: Float
   ): NoticeResponse!
   getNoticeByNoticeId(id: String!): Notice!
-  getNoticesForEveryDepartments(count: Float!): [[Notice!]!]!
+  getNoticesForEveryDepartments(count: Float!): [Notice!]!
   getPaginatedNotice(
     """Paginate after opaque cursor"""
     after: String


### PR DESCRIPTION

기존 getNoticesForEveryDepartments 리졸버의 처리시간이 5초 이상 걸리는 성능 이슈를 처리하기 위함.

<img width="1005" alt="스크린샷 2021-06-11 오후 5 50 10" src="https://user-images.githubusercontent.com/54267479/121659675-7e458300-cadd-11eb-96a3-bc81d04edaf6.png">

비동기 for문으로 이뤄져있는 로직을 단일 db쿼리를 통해 해결할 예정

```JavaScript
  @Query(() => [[NoticeType]])
  async getNoticesForEveryDepartments(@Args('count') limit: number) {
    const departments = await this.departmentService.getAllDepartment();
    const notices: Notice[][] = [];
    for (const { id } of departments) {
      const [
        notice,
      ] = await this.noticeService.getPaginatedNoticeByDepartmentId(
        id,
        limit,
        0,
      );
      notices.push(notice);
    }
    return Promise.all(notices);
  }
```

위 코드를 수정할것임